### PR TITLE
BAU Bump dependencies

### DIFF
--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/controllers/HelloWorldController.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/controllers/HelloWorldController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/controllers/LanguageSwitchController.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/controllers/LanguageSwitchController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/ErrorTemplate.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/Head.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/Head.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/HelloWorldPage.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/HelloWorldPage.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/LanguageSelect.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/LanguageSelect.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/Layout.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,5 @@
 # microservice specific routes
 
-->         /govuk-frontend          govuk.Routes
 ->         /hmrc-frontend           hmrcfrontend.Routes
 GET        /hello-world             uk.gov.hmrc.buildanddeploycanaryservice.controllers.HelloWorldController.helloWorld
 GET        /language/:lang          uk.gov.hmrc.buildanddeploycanaryservice.controllers.LanguageSwitchController.switchToLanguage(lang: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,14 +6,13 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.12.0",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.0.0-play-28",
-    "uk.gov.hmrc"             %% "play-frontend-govuk"        % "1.0.0-play-28",
+    "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.18.0",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.31.0-play-28",
     "uk.gov.hmrc"             %% "play-language"              % "5.1.0-play-28"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.12.0" % Test,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % "5.18.0" % Test,
     "org.scalatest"           %% "scalatest"                % "3.2.3"  % Test,
     "org.jsoup"               %  "jsoup"                    % "1.13.1" % Test,
     "com.typesafe.play"       %% "play-test"                % current  % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.4.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.6.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.7.5")
 addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"        % "1.4.11")

--- a/test/uk/gov/hmrc/buildanddeploycanaryservice/controllers/HelloWorldControllerSpec.scala
+++ b/test/uk/gov/hmrc/buildanddeploycanaryservice/controllers/HelloWorldControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Bump dependencies according to the catalogue
- Remove play-frontend-govuk as per https://confluence.tools.tax.service.gov.uk/display/TEC/2021/08/25/Archiving+of+the+standalone+play-frontend-govuk+library
- Copyright declartions have been automatically updated