### PR TITLE
PBD-4187 Attempt to fail missing config before hello-world page loads

### DIFF
--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
@@ -29,8 +29,6 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val cy: String            = "cy"
   val defaultLanguage: Lang = Lang(en)
 
-  val myString: String = config.getOptional[String]("some.config.key").getOrElse("")
-  val shouldFail: String = config.getOptional[String]("another.config.key").getOrElse("false")
   val requiredEnvVar: String = sys.env.getOrElse("SERVICE_WILL_FAIL_TO_START_WITHOUT_THIS_ENV_VAR", "")
   val requiredSystemProperty: String = config.getOptional[String]("service.will.fail.to.start.without.this.sys.prop").getOrElse("")
 
@@ -41,4 +39,6 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   if (requiredSystemProperty == "") {
     throw new Exception
   }
+
+  val someConfigKey: String = config.getOptional[String]("some.config.key").getOrElse("")
 }

--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/views/HelloWorldPage.scala.html
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/views/HelloWorldPage.scala.html
@@ -23,5 +23,7 @@
 @layout(pageTitle = Some("build-and-deploy-canary-service")) {
     <h1 class="govuk-heading-xl">build-and-deploy-canary-service</h1>
     <p class="govuk-body">@{messages("service.text")}</p>
-    <p class="govuk-body">@{appConfig.myString}</p>
+    <p class="govuk-body">someConfigKey: @{appConfig.someConfigKey}</p>
+    <p class="govuk-body">requiredEnvVar: @{appConfig.requiredEnvVar}</p>
+    <p class="govuk-body">requiredEnvVar: @{appConfig.requiredSystemProperty}</p>
 }


### PR DESCRIPTION
- Attempting to reorder config loading so that the exceptions are raised before all of the config items required by HelloWorld are ready. Does this make it fail more reliably?
- Add all config items to the HTML and make the naming/labeling more consistent
- Removed unused/redundant shoudFail config item