### PR TITLE
Update to use Play 3.0

### DIFF
--- a/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/buildanddeploycanaryservice/config/AppConfig.scala
@@ -31,14 +31,15 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   val requiredEnvVar: String = sys.env.getOrElse("SERVICE_WILL_FAIL_TO_START_WITHOUT_THIS_ENV_VAR", "")
   val requiredSystemProperty: String = config.getOptional[String]("service.will.fail.to.start.without.this.sys.prop").getOrElse("")
-
+ 
   if (requiredEnvVar == "") {
     throw new Exception
   }
-
+  
   if (requiredSystemProperty == "") {
     throw new Exception
   }
+  
 
   val someConfigKey: String = config.getOptional[String]("some.config.key").getOrElse("")
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,13 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "build-and-deploy-canary-service"
 
-val silencerVersion = "1.7.8"
+val silencerVersion = "1.7.14"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(
     majorVersion                     := 0,
-    scalaVersion                     := "2.13.8",
+    scalaVersion                     := "2.13.12",
     libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
     TwirlKeys.templateImports ++= Seq(
       "uk.gov.hmrc.buildanddeploycanaryservice.config.AppConfig",

--- a/build.sbt
+++ b/build.sbt
@@ -17,15 +17,8 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.hmrcfrontend.views.html.components._",
       "uk.gov.hmrc.hmrcfrontend.views.html.helpers._"
     ),
-    // ***************
-    // Use the silencer plugin to suppress warnings
-    // You may turn it on for `views` too to suppress warnings from unused imports in compiled twirl templates, but this will hide other warnings.
-    scalacOptions += "-P:silencer:pathFilters=routes",
-    libraryDependencies ++= Seq(
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
-    )
-    // ***************
+    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s", 
+    scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s"
   )
   .configs(IntegrationTest)
   .settings(integrationTestSettings(): _*)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,3 @@
 # Add all the application routes to the app.routes file
 ->         /build-and-deploy-canary-service              app.Routes
 ->         /                          health.Routes
-
-GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,7 @@ object AppDependencies {
 
   val test = Seq(
     "uk.gov.hmrc"        %% "bootstrap-test-play-28" % bootstrapPlayVersion % Test,
-    "org.jsoup"          %  "jsoup"                  % "1.13.1"             % Test,
-    "za.co.absa.commons" %% "commons"                % "1.3.0"              % Test
+    "org.jsoup"          %  "jsoup"                  % "1.17.1"             % Test,
+    "za.co.absa.commons" %% "commons"                % "1.3.6"              % Test
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapPlayVersion = "7.22.0"
+  val bootstrapPlayVersion = "8.1.0"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.23.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.29.0-play-28",
   )
 
   val test = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,12 +8,12 @@ object AppDependencies {
   val bootstrapPlayVersion = "8.1.0"
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.29.0-play-28",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
+    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "8.0.0",
   )
 
   val test = Seq(
-    "uk.gov.hmrc"        %% "bootstrap-test-play-28" % bootstrapPlayVersion % Test,
+    "uk.gov.hmrc"        %% "bootstrap-test-play-30" % bootstrapPlayVersion % Test,
     "org.jsoup"          %  "jsoup"                  % "1.17.1"             % Test,
     "za.co.absa.commons" %% "commons"                % "1.3.6"              % Test
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.15.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.20")
-addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"        % "1.4.11")
+addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"        % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.15.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.20")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.4.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.0")
 addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"        % "1.5.1")


### PR DESCRIPTION
- BAU: Update Scala and silence
- BAU: No longer need to be implicit with  kenshoo
- BAU: Update play-hmrc-frontend to latest
- BAU: Update all app dependencies
- BAU: Update to Play to use Play 3.0
